### PR TITLE
Changing the event that 'triggers' the workflow.

### DIFF
--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -1,6 +1,6 @@
 name: Delete PR Branches on Merge
 
-on: pull_request
+on: push
 jobs:
   cleanup:
     name: Cleanup


### PR DESCRIPTION
Apparently, GitHub doesn't fire off events for the 'pull_request' type
when a PR is merged.

This will hopefully get the auto-delete-branches workflow working. 